### PR TITLE
Fix csv parsing errors discovered while trying to parse Tracula generated data

### DIFF
--- a/afqbrowser/site/client/js/3d-brain.js
+++ b/afqbrowser/site/client/js/3d-brain.js
@@ -152,7 +152,7 @@ afqb.three.buildthreeGui = function (streamlinesExist) {
 
         // Update the query string
         afqb.global.updateQueryString(
-            {three: {fiberRepresentation: value.toLowerCase().replace(/\s+/g, "-")}}
+            {three: {fiberRepresentation: afqb.global.formatKeyName(value)}}
         );
 
     });
@@ -271,7 +271,7 @@ afqb.three.init = function (callback) {
     // load fiber bundle using jQuery
     $.getJSON("data/streamlines.json", function (json) {
         var names = afqb.plots.tracts.map(function(name) {
-            return name.toLowerCase().replace(/\s+/g, "-");
+            return afqb.global.formatKeyName(name);
         });
 
         var streamlinesExist = false;
@@ -279,7 +279,7 @@ afqb.three.init = function (callback) {
         Object.keys(json).forEach(function (bundleKey) {
             var oneBundle = json[bundleKey];
 
-            var keyName = bundleKey.toLowerCase().replace(/\s+/g, "-");
+            var keyName = afqb.global.formatKeyName(bundleKey);
             var index = names.indexOf(keyName);
 
             // Retrieve the core fiber and then delete it from the bundle object
@@ -507,7 +507,7 @@ afqb.three.init = function (callback) {
                     domEvents.addEventListener(child, 'mouseup', function() {
                         if(!afqb.global.mouse.mouseMove) {
                             var myBundle = d3.selectAll("input.tracts").filter(function (d) {
-                                return d.toLowerCase().replace(/\s+/g, "-") === child.name;
+                                return afqb.global.formatKeyName(d) === child.name;
                             })[0][0];
                             myBundle.checked = !myBundle.checked;
                             afqb.plots.settings.checkboxes[myBundle.name] = myBundle.checked;
@@ -719,7 +719,7 @@ afqb.three.highlightBundle = function (state, name) {
 
 afqb.three.mouseoutBundle = function (child) {
     var myBundle = d3.selectAll("input.tracts").filter(function (d) {
-    	return d.toLowerCase().replace(/\s+/g, "-") === child.name;
+    	return afqb.global.formatKeyName(d) === child.name;
     })[0][0];
     if (afqb.global.controls.threeControlBox.fiberRepresentation === 'all fibers') {
         var groups = [afqb.three.colorGroup, afqb.three.greyGroup];

--- a/afqbrowser/site/client/js/save-settings.js
+++ b/afqbrowser/site/client/js/save-settings.js
@@ -1,6 +1,12 @@
 // Tell jslint that certain variables are global
 /* global afqb, FileReader, d3, d3_queue, THREE */
 
+afqb.global.formatKeyName = function(bundle) {
+    // Standardize bundle names by making them lower case and
+    // replacing all dots and spaces with dashes
+    return bundle.toLowerCase().replace(/\s+/g, "-").replace(/\./g, "-");
+};
+
 afqb.global.updateQueryString = function(queryObj) {
     "use strict";
 

--- a/afqbrowser/site/client/js/sortable-table.js
+++ b/afqbrowser/site/client/js/sortable-table.js
@@ -121,7 +121,7 @@ afqb.table.buildTable = function (error, useless, data) {
 
             // Update the query string
             afqb.global.updateQueryString(
-                {table: {splitMethod: value.toLowerCase().replace(/\s+/g, "-")}}
+                {table: {splitMethod: afqb.global.formatKeyName(value)}}
             );
 
             afqb.table.refreshTable();

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -48,7 +48,7 @@ afqb.plots.buildTractCheckboxes = function (error, data) {
     }
 
     afqb.plots.tracts.forEach(function (element) {
-        var tractName = element.toLowerCase().replace(/\s+/g, "-");
+        var tractName = afqb.global.formatKeyName(element);
         if (!afqb.plots.settings.brushes.hasOwnProperty(tractName)) {
             afqb.plots.settings.brushes[tractName] = {
             	brushOn: false,
@@ -63,13 +63,13 @@ afqb.plots.buildTractCheckboxes = function (error, data) {
 	svg.append('input')
 		.attr("type", "checkbox")
 		.attr("class", "tracts")
-		.attr("id", function (d) { return "input-" + d.toLowerCase().replace(/\s+/g, "-"); })
-		.attr("name", function (d) { return d.toLowerCase().replace(/\s+/g, "-"); });
+		.attr("id", function (d) { return "input-" + afqb.global.formatKeyName(d); })
+		.attr("name", function (d) { return afqb.global.formatKeyName(d); });
 	// add label to the checkboxes
 	svg.append('label')
 		.text(function (d) { return d; })
-		.attr("for", function (d) { return "input-" + d.toLowerCase().replace(/\s+/g, "-"); })
-		.attr("id", function (d) { return "label-" + d.toLowerCase().replace(/\s+/g, "-"); });
+		.attr("for", function (d) { return "input-" + afqb.global.formatKeyName(d); })
+		.attr("id", function (d) { return "label-" + afqb.global.formatKeyName(d); });
 
 	//add event handler to the checkbox
 	d3.selectAll(".tracts")
@@ -200,9 +200,16 @@ afqb.plots.buildPlotGui = function (error, data) {
     "use strict";
 	if (error) { throw error; }
 
+    var nonMetricCols = ['subjectID', 'tractID', 'nodeID'];
+    var nodeKeys = Object.keys(data[0]).filter(function (element) {
+        return !nonMetricCols.includes(element);
+    });
+
+    var plotKey = nodeKeys.includes(afqb.plots.settings.plotKey) ? afqb.plots.settings.plotKey : nodeKeys[0];
+
 	var plotsGuiConfigObj = function () {
 		this.brushTract = afqb.plots.settings.brushTract;
-		this.plotKey = afqb.plots.settings.plotKey;
+		this.plotKey = plotKey;
 		this.lineOpacity = parseFloat(afqb.plots.settings.lineOpacity);
         this.errorType = afqb.plots.settings.errorType;
 	};
@@ -217,8 +224,6 @@ afqb.plots.buildPlotGui = function (error, data) {
 	plotsGuiContainer.appendChild(afqb.plots.gui.domElement);
 
 	afqb.global.controls.plotsControlBox = new plotsGuiConfigObj();
-
-	var nodeKeys = Object.keys(data[0]).slice(3);
 
     // Add key controller
 	afqb.plots.gui
@@ -313,9 +318,11 @@ afqb.plots.ready = function (error, data) {
 
 	var plotKey = afqb.global.controls.plotsControlBox.plotKey;
 
+	console.log(data);
 	data = data.filter(function (d) {
 		return Boolean(d[plotKey]);
 	});
+    console.log(data);
 
     afqb.plots.yzooms[plotKey] = d3.behavior.zoom()
         .y(afqb.plots.yScale)
@@ -338,6 +345,7 @@ afqb.plots.ready = function (error, data) {
     }
 
 	afqb.plots.lastPlotKey = plotKey;
+    console.log(plotKey);
 
 	afqb.plots.tractData = d3.nest()
 		.key(function (d) { return d.tractID; })
@@ -355,8 +363,8 @@ afqb.plots.ready = function (error, data) {
 	//initialize panels for each tract - and attach tract data with them
 	var trPanels = d3.select("#tractdetails").selectAll("svg").data(afqb.plots.tractData);
 	trPanels.enter().append("svg")
-		.attr("id", function (d,i) { return "tract-" + afqb.plots.tracts[i].toLowerCase().replace(/\s+/g, "-"); })
-        .attr("name", function (d,i) { return afqb.plots.tracts[i].toLowerCase().replace(/\s+/g, "-"); })
+		.attr("id", function (d,i) { return "tract-" + afqb.global.formatKeyName(afqb.plots.tracts[i]); })
+        .attr("name", function (d,i) { return afqb.global.formatKeyName(afqb.plots.tracts[i]); })
 		.attr("width", afqb.plots.w + afqb.plots.m.left + afqb.plots.m.right + 40)
 		.attr("height", afqb.plots.h + afqb.plots.m.top + afqb.plots.m.bottom + afqb.plots.axisOffset.bottom)
 		.attr("display", "none")
@@ -422,7 +430,7 @@ afqb.plots.ready = function (error, data) {
 		.text(function(d,i) { return afqb.plots.tracts[i]; });
 
     trPanels.append("text")
-        .attr("id", function (d,i) { return "brush-ext-" + afqb.plots.tracts[i].toLowerCase().replace(/\s+/g, "-"); })
+        .attr("id", function (d,i) { return "brush-ext-" + afqb.global.formatKeyName(afqb.plots.tracts[i]); })
         .attr("class", "brushExt")
         .attr("text-anchor", "end")
         .attr("transform", "translate("+ (afqb.plots.w + afqb.plots.m.right + 30)
@@ -572,7 +580,7 @@ afqb.plots.ready = function (error, data) {
 	}
 
     d3.select("#tractdetails").selectAll("svg").each(function (d) {
-        afqb.plots.newBrush(d.key.toLowerCase().replace(/\s+/g, "-"));
+        afqb.plots.newBrush(afqb.global.formatKeyName(d.key));
     });
 };
 
@@ -866,10 +874,12 @@ afqb.plots.showHideTractDetails = function (state, name) {
 	if (state === true){
 		d3.select("#tract-" + name).style("display", "inline");
 		var names = afqb.plots.tracts.map(function(name) {
-			return name.toLowerCase().replace(/\s+/g, "-");
+			return afqb.global.formatKeyName(name);
 		});
 		var index = names.indexOf(name);
 		var color = afqb.global.d3colors[parseInt(index)];
+		console.log(name);
+		console.log(index);
 		d3.select("#label-" + name).style("color", color);
 	} else {
 		d3.select("#tract-" + name).style("display", "none");


### PR DESCRIPTION
This PR fixes a few errors in the nodes.csv parsing discovered while trying to parse tracula generated data.

- Previously, the available plot keys (i.e. "Metrics") in the plot controls menu were populated by taking the column headers from `nodes.csv` and eliminating the first three columns. This PR uses index-independent formatting for the plotKey selection by taking all column headers except for `subjectID`, `nodeID`, and `tractID`.

- Since some tracula generated tract names have dots in them, this PR also reformats all tract names, replacing dots with dashes. This key name reformatting is not in a separate function `afqb.global.formatKeyName()`.