### PR TITLE
Fix subject selection for tracula generated data

### DIFF
--- a/afqbrowser/site/client/js/sortable-table.js
+++ b/afqbrowser/site/client/js/sortable-table.js
@@ -29,7 +29,9 @@ afqb.table.buildTable = function (error, useless, data) {
 
 	data.forEach(function (d) {
         if (typeof d.subjectID === 'number') {
-            d.subjectID = "s" + d.subjectID.toString();
+            d.subjectID = "s" + afqb.global.formatKeyName(d.subjectID.toString());
+        } else {
+            d.subjectID = afqb.global.formatKeyName(d.subjectID);
         }
 		afqb.table.subData.push(d);
 	});

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -312,8 +312,10 @@ afqb.plots.ready = function (error, data) {
 
 	data.forEach(function (d) {
 		if (typeof d.subjectID === 'number') {
-			d.subjectID = "s" + d.subjectID.toString();
-        }
+			d.subjectID = "s" + afqb.global.formatKeyName(d.subjectID.toString());
+        } else {
+			d.subjectID = afqb.global.formatKeyName(d.subjectID);
+		}
 	});
 
 	var plotKey = afqb.global.controls.plotsControlBox.plotKey;
@@ -444,7 +446,7 @@ afqb.plots.ready = function (error, data) {
 		.enter().append("g")
 		.attr("class", "tracts")
 		.attr("id", function (d) {
-				return d.values[0].subjectID;
+            return d.values[0].subjectID;
 		})
 		.on("mouseover", mouseover)
 		.on("mouseout", mouseout)
@@ -594,7 +596,9 @@ afqb.plots.changePlots = function (error, data) {
 
 	data.forEach(function (d) {
 		if (typeof d.subjectID === 'number'){
-			d.subjectID = "s" + d.subjectID.toString();
+			d.subjectID = "s" + afqb.global.formatKeyName(d.subjectID.toString());
+        } else {
+            d.subjectID = afqb.global.formatKeyName(d.subjectID);
         }
 	});
 

--- a/afqbrowser/site/client/js/tract-details.js
+++ b/afqbrowser/site/client/js/tract-details.js
@@ -320,11 +320,9 @@ afqb.plots.ready = function (error, data) {
 
 	var plotKey = afqb.global.controls.plotsControlBox.plotKey;
 
-	console.log(data);
 	data = data.filter(function (d) {
 		return Boolean(d[plotKey]);
 	});
-    console.log(data);
 
     afqb.plots.yzooms[plotKey] = d3.behavior.zoom()
         .y(afqb.plots.yScale)
@@ -347,7 +345,6 @@ afqb.plots.ready = function (error, data) {
     }
 
 	afqb.plots.lastPlotKey = plotKey;
-    console.log(plotKey);
 
 	afqb.plots.tractData = d3.nest()
 		.key(function (d) { return d.tractID; })
@@ -882,8 +879,6 @@ afqb.plots.showHideTractDetails = function (state, name) {
 		});
 		var index = names.indexOf(name);
 		var color = afqb.global.d3colors[parseInt(index)];
-		console.log(name);
-		console.log(index);
 		d3.select("#label-" + name).style("color", color);
 	} else {
 		d3.select("#tract-" + name).style("display", "none");


### PR DESCRIPTION
The tracula subject names contained dots, which make for invalid selectors when subjectID are used a html element IDs. This PR fixes that issue by using `afqb.global.formatKeyName()` on subjectIDs.